### PR TITLE
Première version du tri sur les stages

### DIFF
--- a/_data/stages.yml
+++ b/_data/stages.yml
@@ -1404,7 +1404,7 @@ stages:
 - name: Fun Multisports & Natation
   img: "/stages/decouvertesportiveetculturelle/funmultietnat.png"
   inscription: ''
-  categorie: Les petits bouts
+  categorie: Activités sportives
   online: true
   nouveau: true
   stage_une: false

--- a/_includes/coleen/liste_cartes.html
+++ b/_includes/coleen/liste_cartes.html
@@ -7,7 +7,21 @@
 }
 </style>
 
-<div class="col-md-4 col-xs-12">
+{% if stage.categorie contains 'Activités artistiques et loisirs' %}
+{% assign categorie = 'artistique' %}
+{% elsif stage.categorie contains 'Les petits bouts' %}
+{% assign categorie = 'bouts' %}
+{% elsif stage.categorie contains 'Danse et Gymnastique' %}
+{% assign categorie = 'danse' %}
+{% elsif stage.categorie contains 'Activités fun' %}
+{% assign categorie = 'fun' %}
+{% elsif stage.categorie contains 'Découvertes sportives et culturelles' %}
+{% assign categorie = 'sportive' %}
+{% elsif stage.categorie contains 'Activités sportives' %}
+{% assign categorie = 'culturelles' %}
+{% endif %}
+
+<div class="column {{ categorie }} col-md-4 col-xs-12">
   <div class="card-2">
     <div class="image">
       <a data-toggle="modal" data-target="#{{stage.name | replace: ' ', '_' | replace: '&', 'et' }}"><img src="{{ BASE_PATH }}/assets/images{{ stage.img }}"></a>

--- a/assets/js/tri.js
+++ b/assets/js/tri.js
@@ -1,0 +1,43 @@
+filterSelection("all")
+function filterSelection(c) {
+  var x, i;
+  x = document.getElementsByClassName("column");
+  if (c == "all") c = "";
+  for (i = 0; i < x.length; i++) {
+    w3RemoveClass(x[i], "show");
+    if (x[i].className.indexOf(c) > -1) w3AddClass(x[i], "show");
+  }
+}
+
+function w3AddClass(element, name) {
+  var i, arr1, arr2;
+  arr1 = element.className.split(" ");
+  arr2 = name.split(" ");
+  for (i = 0; i < arr2.length; i++) {
+    if (arr1.indexOf(arr2[i]) == -1) {element.className += " " + arr2[i];}
+  }
+}
+
+function w3RemoveClass(element, name) {
+  var i, arr1, arr2;
+  arr1 = element.className.split(" ");
+  arr2 = name.split(" ");
+  for (i = 0; i < arr2.length; i++) {
+    while (arr1.indexOf(arr2[i]) > -1) {
+      arr1.splice(arr1.indexOf(arr2[i]), 1);     
+    }
+  }
+  element.className = arr1.join(" ");
+}
+
+
+// Add active class to the current button (highlight it)
+var btnContainer = document.getElementById("myBtnContainer");
+var btns = btnContainer.getElementsByClassName("btn");
+for (var i = 0; i < btns.length; i++) {
+  btns[i].addEventListener("click", function(){
+    var current = document.getElementsByClassName("active");
+    current[0].className = current[0].className.replace(" active", "");
+    this.className += " active";
+  });
+}

--- a/pages/stages_enfants/activites.html
+++ b/pages/stages_enfants/activites.html
@@ -4,20 +4,72 @@ title: Catalogue des stages
 permalink: "/stages/activites/"
 menu: stages
 description: ''
+js: tri.js
 
 ---
-{% include annonces/stages.html %}
 
-<p>Ci-dessous tous les stages que nous vous proposons.<br>
-Vous pouvez sélectionner une catégorie pour peaufiner votre recherche.</p>
+<style>
+* {
+  box-sizing: border-box;
+}
+
+/* Center website */
+.main {
+  max-width: 1000px;
+  margin: auto;
+}
+
+/* Create three equal columns that floats next to each other */
+.column {
+  display: none; /* Hide all elements by default */
+}
+
+/* Clear floats after rows */ 
+.row:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+/* Content */
+.content {
+  background-color: white;
+  padding: 10px;
+}
+
+/* The "show" class is added to the filtered elements */
+.show {
+  display: block;
+}
+
+/* Style the buttons */
+.btn.active {
+  color: white;
+}
+
+.tri{
+
+}
+
+</style>
+
+<div id="myBtnContainer">
+  <div class="offset-md-3 col-md-6 btn btn-block btn-info-filled tri active" onclick="filterSelection('all')"> Voir tous les stages</div>
+  <div class="col-lg-4 col-md-6 col-sm-6 col-xs-6 btn btn-block btn-info-filled tri" onclick="filterSelection('bouts')"> Les petits bouts</div>
+  <div class="col-lg-4 col-md-6 col-sm-6 col-xs-6 btn btn-block btn-info-filled tri" onclick="filterSelection('culturelles')"> Découvertes sportives et culturelles</div>
+  <div class="col-lg-4 col-md-6 col-sm-6 col-xs-6 btn btn-block btn-info-filled tri" onclick="filterSelection('danse')"> Danse et Gymnastique</div>
+  <div class="col-lg-4 col-md-6 col-sm-6 col-xs-6 btn btn-block btn-info-filled tri" onclick="filterSelection('fun')"> Activités Fun</div>
+  <div class="col-lg-4 col-md-6 col-sm-6 col-xs-6 btn btn-block btn-info-filled tri" onclick="filterSelection('sportive')"> Activités Sportives</div>
+  <div class="col-lg-4 col-md-6 col-sm-6 col-xs-6 btn btn-block btn-info-filled tri" onclick="filterSelection('artistique')"> Activités artistiques et loisirs</div>
+</div>
 
 <div class="row">
 	{% assign liste_stages = site.data.stages.stages | sort: "name" %}
 	{% for stage in liste_stages %}
-  {% if stage.online %}
+		{% if stage.online %}
 
-{% include coleen/liste_cartes.html %}
+			{% include coleen/liste_cartes.html %}
 
-  {% endif %}
+  		{% endif %}
 	{% endfor %}
 </div>


### PR DESCRIPTION
Première version.

La version précédente est peu utilisée, et nécessite un temps de chargement très long alors que la page a déjà été chargée dans le catalogue global. L'idée est que le visiteur puisse ne charger qu'une seule fois la page pour économiser sa connexion et améliorer sa vitesse de chargement.

La version de test est disponible ici: [Pull request #123](https://deploy-preview-123--lecfs.netlify.app/stages/activites/).

Commentaires à envoyer à [romain@lecfs.be](mailto:romain@lecfs.be), où à compléter ci-dessous en créant un compte sur [Github](https://github.com/join).

Améliorations nécessaires sur plusieurs points:

### Version ordi
- [ ] Espace nécessaire entre les boutons de tri et les cartes de stage.
- [ ] Le titre semble vraiment pas centré, alors qu'il l'est sur la page, mais le menu de gauche donne une mauvaise illusion.
- [ ] Suppression des catégories dans le menu de gauche

### Version mobile
- [ ] Espace nécessaire entre les boutons de tri et les cartes de stage.
- [ ] Renommer les catégories pour pouvoir garder deux boutons par page.
- [ ] Rajouter les boutons en bas de page pour plus de facilité ?
- [ ] Suppression des sousmenus du catalogue de stages

### Si on adhère à cette version
- [ ] Adaptation des activités extrascolaires
- [ ] Adaptation des activités parascolaires
- [ ] Possibilité de tri sur les horaires des cours adultes